### PR TITLE
Fixing issue with progress not showing

### DIFF
--- a/online/waves.php
+++ b/online/waves.php
@@ -373,7 +373,7 @@ $q = "SELECT sc.id, sc.name, sc.build_ticks FROM scan_class AS sc, rc ".
 
 $qq = "SELECT scan_id, sum(num), build_ticks FROM scan_build ".
       "WHERE planet_id='$Planetid' ".
-      "AND build_ticks!=0 GROUP BY scan_id, build_ticks";
+      "AND build_ticks!=0 GROUP BY scan_id, build_ticks ORDER BY scan_id ASC";
 
 $result = mysqli_query ($db, $q );
 if (mysqli_num_rows($result) > 0) {


### PR DESCRIPTION
May also apply to other pages with a production table, but as the scan_build has no unique column, the return order is random/in the order of being built, so if the scan_id's are skipped (i.e. scan ID 3 is listed before 1 or 2), the build progress or the earlier scans do not show.

This is using MySQL